### PR TITLE
Add svelte.config.js to templates

### DIFF
--- a/packages/sapper-template/rollup.config.js
+++ b/packages/sapper-template/rollup.config.js
@@ -4,27 +4,13 @@ import commonjs from "rollup-plugin-commonjs";
 import svelte from "rollup-plugin-svelte";
 import babel from "rollup-plugin-babel";
 import { terser } from "rollup-plugin-terser";
+import typescript from "rollup-plugin-typescript2";
 import config from "sapper/config/rollup.js";
 import pkg from "./package.json";
-import typescript from "rollup-plugin-typescript2";
 
-import {
-    preprocess,
-    createEnv,
-    readConfigFile
-} from "@pyoner/svelte-ts-preprocess";
+const svelteOptions = require("./svelte.config");
 
 const production = !process.env.ROLLUP_WATCH;
-
-const env = createEnv();
-const compilerOptions = readConfigFile(env);
-const opts = {
-    env,
-    compilerOptions: {
-        ...compilerOptions,
-        allowNonTsExtensions: true
-    }
-};
 
 const mode = process.env.NODE_ENV;
 const dev = mode === "development";
@@ -45,10 +31,10 @@ export default {
                 "process.env.NODE_ENV": JSON.stringify(mode)
             }),
             svelte({
+                ...svelteOptions,
                 dev,
                 hydratable: true,
                 emitCss: true,
-                preprocess: preprocess(opts)
             }),
             resolve({
                 browser: true
@@ -98,9 +84,9 @@ export default {
                 "process.env.NODE_ENV": JSON.stringify(mode)
             }),
             svelte({
+                ...svelteOptions,
                 generate: "ssr",
                 dev,
-                preprocess: preprocess(opts)
             }),
             resolve(),
             commonjs(),

--- a/packages/sapper-template/svelte.config.js
+++ b/packages/sapper-template/svelte.config.js
@@ -1,0 +1,23 @@
+// svelte options exported for svelte-vscode
+
+const {
+  preprocess: makeTsPreprocess,
+  createEnv,
+  readConfigFile,
+} = require("@pyoner/svelte-ts-preprocess");
+
+const env = createEnv();
+const compilerOptions = readConfigFile(env);
+const preprocessOptions = {
+  env,
+  compilerOptions: {
+    ...compilerOptions,
+    allowNonTsExtensions: true,
+  },
+};
+const preprocess = makeTsPreprocess(preprocessOptions);
+
+module.exports = {
+  dev: process.env.NODE_ENV !== "development",
+  preprocess,
+};

--- a/packages/template/rollup.config.js
+++ b/packages/template/rollup.config.js
@@ -5,23 +5,9 @@ import livereload from "rollup-plugin-livereload";
 import { terser } from "rollup-plugin-terser";
 import typescript from "rollup-plugin-typescript2";
 
-import {
-  preprocess,
-  createEnv,
-  readConfigFile
-} from "@pyoner/svelte-ts-preprocess";
+const svelteOptions = require("./svelte.config");
 
 const production = !process.env.ROLLUP_WATCH;
-
-const env = createEnv();
-const compilerOptions = readConfigFile(env);
-const opts = {
-  env,
-  compilerOptions: {
-    ...compilerOptions,
-    allowNonTsExtensions: true
-  }
-};
 
 export default {
   input: "src/main.ts",
@@ -33,6 +19,7 @@ export default {
   },
   plugins: [
     svelte({
+      ...svelteOptions,
       // enable run-time checks when not in production
       dev: !production,
       // we'll extract any component CSS out into
@@ -40,7 +27,6 @@ export default {
       css: css => {
         css.write("public/bundle.css");
       },
-      preprocess: preprocess(opts)
     }),
 
     // If you have external dependencies installed from

--- a/packages/template/svelte.config.js
+++ b/packages/template/svelte.config.js
@@ -1,0 +1,23 @@
+// svelte options exported for svelte-vscode
+
+const {
+  preprocess: makeTsPreprocess,
+  createEnv,
+  readConfigFile,
+} = require("@pyoner/svelte-ts-preprocess");
+
+const env = createEnv();
+const compilerOptions = readConfigFile(env);
+const preprocessOptions = {
+  env,
+  compilerOptions: {
+    ...compilerOptions,
+    allowNonTsExtensions: true,
+  },
+};
+const preprocess = makeTsPreprocess(preprocessOptions);
+
+module.exports = {
+  dev: process.env.NODE_ENV !== "development",
+  preprocess,
+};


### PR DESCRIPTION
Closes https://github.com/pyoner/svelte-typescript/issues/11.

Hi there! First things first -- thanks for this repo.

I've moved preprocess options to `svelte.config.js` files, where svelte-vscode can read them.
I think it would be nice to have this out of the box and avoid Svelte parse errors when starting from the template. VSCode is _the editor_ for TypeScript and I suppose other editor extensions could hypothetically read this file too.


